### PR TITLE
Allow building neolib as shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,13 +33,15 @@ file(GLOB_RECURSE HEADER_FILES include/*.*)
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCE_FILES} ${PLATFORM_SOURCE_FILES} ${HEADER_FILES})
 
 add_definitions(-DNEOLIB_HOSTED_ENVIRONMENT)
-add_library(neolib STATIC ${SOURCE_FILES} ${PLATFORM_SOURCE_FILES} ${HEADER_FILES})
+add_library(neolib ${SOURCE_FILES} ${PLATFORM_SOURCE_FILES} ${HEADER_FILES})
 target_include_directories(neolib PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 set_property(TARGET neolib PROPERTY CXX_STANDARD 17)
 set_property(TARGET neolib PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 set_property(TARGET neolib PROPERTY CXX_VISIBILITY_PRESET hidden)
+set_property(TARGET neolib PROPERTY SOVERSION ${PROJECT_VERSION_MAJOR})
+set_property(TARGET neolib PROPERTY VERSION ${PROJECT_VERSION})
 
 include(GenerateExportHeader)
 generate_export_header(neolib EXPORT_FILE_NAME include/neolib/neolib_export.hpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ target_include_directories(neolib PUBLIC
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 set_property(TARGET neolib PROPERTY CXX_STANDARD 17)
 set_property(TARGET neolib PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+set_property(TARGET neolib PROPERTY CXX_VISIBILITY_PRESET hidden)
 
 include(GenerateExportHeader)
 generate_export_header(neolib EXPORT_FILE_NAME include/neolib/neolib_export.hpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,10 @@ target_include_directories(neolib PUBLIC
 set_property(TARGET neolib PROPERTY CXX_STANDARD 17)
 set_property(TARGET neolib PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
+include(GenerateExportHeader)
+generate_export_header(neolib EXPORT_FILE_NAME include/neolib/neolib_export.hpp)
+target_include_directories(neolib PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>")
+
 # dependencies
 find_package(Threads REQUIRED)
 target_link_libraries(neolib PUBLIC Threads::Threads)
@@ -56,7 +60,7 @@ configure_package_config_file(neolibConfig.cmake.in neolibConfig.cmake INSTALL_D
 write_basic_package_version_file(neolibConfigVersion.cmake COMPATIBILITY AnyNewerVersion)
 
 install(TARGETS neolib DESTINATION "${CMAKE_INSTALL_LIBDIR}" EXPORT neolib)
-install(DIRECTORY include/neolib DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(DIRECTORY include/neolib "${CMAKE_CURRENT_BINARY_DIR}/include/neolib" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 install(TARGETS neolib DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 install(EXPORT neolib DESTINATION "${CMAKE_INSTALL_CMAKEDIR}" FILE neolibTargets.cmake NAMESPACE neolib)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/neolibConfig.cmake"

--- a/include/neolib/app/application_info.hpp
+++ b/include/neolib/app/application_info.hpp
@@ -79,7 +79,7 @@ namespace neolib
         vector<string> iArguments;
     };
 
-    class application_info : public i_application_info
+    class NEOLIB_EXPORT application_info : public i_application_info
     {
     public:
         application_info(

--- a/include/neolib/app/module.hpp
+++ b/include/neolib/app/module.hpp
@@ -43,7 +43,7 @@ namespace neolib
 {
     class os_module;
 
-    class module
+    class NEOLIB_EXPORT module
     {
         // types
     private:

--- a/include/neolib/app/os_version.hpp
+++ b/include/neolib/app/os_version.hpp
@@ -13,6 +13,6 @@
 
 namespace neolib
 {
-    std::string os_name();
-    application_info get_application_info(i_application_info const& aAppInfo);
+    NEOLIB_EXPORT std::string os_name();
+    NEOLIB_EXPORT application_info get_application_info(i_application_info const& aAppInfo);
 }

--- a/include/neolib/app/power.hpp
+++ b/include/neolib/app/power.hpp
@@ -43,7 +43,7 @@
 
 namespace neolib
 {
-    class power : public i_power
+    class NEOLIB_EXPORT power : public i_power
     {
     public:
         define_declared_event(ActivityRegistered, activity_registered)

--- a/include/neolib/app/settings.hpp
+++ b/include/neolib/app/settings.hpp
@@ -52,7 +52,7 @@
 
 namespace neolib
 {
-    class settings : public reference_counted<i_settings>
+    class NEOLIB_EXPORT settings : public reference_counted<i_settings>
     {
         template <typename T>
         friend class setting;

--- a/include/neolib/core/any_ref.hpp
+++ b/include/neolib/core/any_ref.hpp
@@ -41,7 +41,7 @@
 
 namespace neolib
 {
-    struct any_const_ref_bad_cast : public std::logic_error 
+    struct any_const_ref_bad_cast : public std::logic_error
     { 
         any_const_ref_bad_cast() : std::logic_error("neolib::any_const_ref_bad_cast") 
         {

--- a/include/neolib/core/crc.hpp
+++ b/include/neolib/core/crc.hpp
@@ -39,5 +39,5 @@
 
 namespace neolib
 {
-    uint32_t crc32(const uint8_t *aData, uint32_t aDataLength);
+    NEOLIB_EXPORT uint32_t crc32(const uint8_t *aData, uint32_t aDataLength);
 }

--- a/include/neolib/core/string_utils.hpp
+++ b/include/neolib/core/string_utils.hpp
@@ -172,7 +172,7 @@ namespace neolib
         return to_upper(std::basic_string<CharT>(1, aCharacter))[0];
     }
 
-    struct string_span : std::pair<std::size_t, std::size_t>
+    struct NEOLIB_EXPORT string_span : std::pair<std::size_t, std::size_t>
     {
         typedef std::pair<std::size_t, std::size_t> span;
         typedef unsigned int type;

--- a/include/neolib/core/uuid.hpp
+++ b/include/neolib/core/uuid.hpp
@@ -88,7 +88,7 @@ namespace neolib
 
     struct unable_to_generate_uuid : std::runtime_error { unable_to_generate_uuid() : std::runtime_error("neolib::unable_to_generate_uuid") {} };
 
-    uuid generate_uuid();
+    NEOLIB_EXPORT uuid generate_uuid();
 
     inline std::istream& operator>>(std::istream& aStream, uuid& aId)
     {

--- a/include/neolib/ecs/ecs.hpp
+++ b/include/neolib/ecs/ecs.hpp
@@ -46,7 +46,7 @@
 
 namespace neolib::ecs
 {
-    class ecs : public neolib::object<i_ecs>
+    class NEOLIB_EXPORT ecs : public neolib::object<i_ecs>
     {
     public:
         define_declared_event(SystemsPaused, systems_paused)

--- a/include/neolib/ecs/entity.hpp
+++ b/include/neolib/ecs/entity.hpp
@@ -41,7 +41,7 @@
 
 namespace neolib::ecs
 {
-    class entity
+    class NEOLIB_EXPORT entity
     {
     public:
         entity(i_ecs& aEcs, entity_id aId);

--- a/include/neolib/ecs/entity_archetype.hpp
+++ b/include/neolib/ecs/entity_archetype.hpp
@@ -45,7 +45,7 @@
 
 namespace neolib::ecs
 {
-    class entity_archetype : public i_entity_archetype
+    class NEOLIB_EXPORT entity_archetype : public i_entity_archetype
     {
     private:
         typedef neolib::set<component_id, std::less<component_id>, neolib::fast_pool_allocator<component_id>> component_list;

--- a/include/neolib/ecs/time.hpp
+++ b/include/neolib/ecs/time.hpp
@@ -41,7 +41,7 @@
 
 namespace neolib::ecs
 {
-    class time : public system<>
+    class NEOLIB_EXPORT time : public system<>
     {
     private:
         class thread;

--- a/include/neolib/file/file.hpp
+++ b/include/neolib/file/file.hpp
@@ -43,34 +43,34 @@
 
 namespace neolib
 {
-    std::string tidy_path(std::string aPath);
-    std::wstring tidy_path(std::wstring aPath);
-    std::string convert_path(const std::wstring& aString);
-    std::wstring convert_path(const std::string& aString);
-    const std::string& create_path(const std::string& aPath);
-    const std::wstring& create_path(const std::wstring& aPath);
-    std::string create_file(const std::string& aFileName);
-    void create_file(const std::wstring& aFileName);
-    bool file_exists(const std::string& aPath);
-    bool file_exists(const std::wstring& aPath);
-    std::time_t file_date(const std::string& aPath);
-    std::time_t file_date(const std::wstring& aPath);
-    std::string file_ext(const std::string& aPath);
-    std::wstring file_ext(const std::wstring& aPath);
-    bool can_read_file(const std::string& aPath);
-    bool can_read_file(const std::wstring& aPath);
-    unsigned long file_size(const std::string& aPath);
-    unsigned long file_size(const std::wstring& aPath);
-    unsigned long long large_file_size(const std::string& aPath);
-    unsigned long long large_file_size(const std::wstring& aPath);
-    int large_file_seek(FILE* aStream, long long aOffset, int aOrigin);
-    bool move_file(const std::string& aPathFrom, const std::string& aPathTo);
-    std::string program_file();
-    std::string program_directory();
-    std::string user_documents_directory();
-    std::string user_settings_directory();
+    NEOLIB_EXPORT std::string tidy_path(std::string aPath);
+    NEOLIB_EXPORT std::wstring tidy_path(std::wstring aPath);
+    NEOLIB_EXPORT std::string convert_path(const std::wstring& aString);
+    NEOLIB_EXPORT std::wstring convert_path(const std::string& aString);
+    NEOLIB_EXPORT const std::string& create_path(const std::string& aPath);
+    NEOLIB_EXPORT const std::wstring& create_path(const std::wstring& aPath);
+    NEOLIB_EXPORT std::string create_file(const std::string& aFileName);
+    NEOLIB_EXPORT void create_file(const std::wstring& aFileName);
+    NEOLIB_EXPORT bool file_exists(const std::string& aPath);
+    NEOLIB_EXPORT bool file_exists(const std::wstring& aPath);
+    NEOLIB_EXPORT std::time_t file_date(const std::string& aPath);
+    NEOLIB_EXPORT std::time_t file_date(const std::wstring& aPath);
+    NEOLIB_EXPORT std::string file_ext(const std::string& aPath);
+    NEOLIB_EXPORT std::wstring file_ext(const std::wstring& aPath);
+    NEOLIB_EXPORT bool can_read_file(const std::string& aPath);
+    NEOLIB_EXPORT bool can_read_file(const std::wstring& aPath);
+    NEOLIB_EXPORT unsigned long file_size(const std::string& aPath);
+    NEOLIB_EXPORT unsigned long file_size(const std::wstring& aPath);
+    NEOLIB_EXPORT unsigned long long large_file_size(const std::string& aPath);
+    NEOLIB_EXPORT unsigned long long large_file_size(const std::wstring& aPath);
+    NEOLIB_EXPORT int large_file_seek(FILE* aStream, long long aOffset, int aOrigin);
+    NEOLIB_EXPORT bool move_file(const std::string& aPathFrom, const std::string& aPathTo);
+    NEOLIB_EXPORT std::string program_file();
+    NEOLIB_EXPORT std::string program_directory();
+    NEOLIB_EXPORT std::string user_documents_directory();
+    NEOLIB_EXPORT std::string user_settings_directory();
 
-    class simple_file
+    class NEOLIB_EXPORT simple_file
     {
         // types
     private:

--- a/include/neolib/file/gunzip.hpp
+++ b/include/neolib/file/gunzip.hpp
@@ -40,7 +40,7 @@
 
 namespace neolib
 {
-    class gunzip
+    class NEOLIB_EXPORT gunzip
     {
         // types
     public:

--- a/include/neolib/io/http.hpp
+++ b/include/neolib/io/http.hpp
@@ -49,7 +49,7 @@
 
 namespace neolib
 {
-    class http_packet : public string_packet
+    class NEOLIB_EXPORT http_packet : public string_packet
     {
         // construction
     public:

--- a/include/neolib/io/oauth.hpp
+++ b/include/neolib/io/oauth.hpp
@@ -47,7 +47,7 @@
 
 namespace neolib
 {
-    class oauth
+    class NEOLIB_EXPORT oauth
     {
         // events
     public:

--- a/include/neolib/io/openssl.hpp
+++ b/include/neolib/io/openssl.hpp
@@ -40,7 +40,7 @@
 
 namespace neolib
 {
-    class openssl
+    class NEOLIB_EXPORT openssl
     {
     private:
         static const std::size_t SEED_BUFFER_SIZE = 8;

--- a/include/neolib/io/uri.hpp
+++ b/include/neolib/io/uri.hpp
@@ -41,7 +41,7 @@
 
 namespace neolib
 {
-    class uri_authority
+    class NEOLIB_EXPORT uri_authority
     {
     public:
         typedef std::string user_information_type;

--- a/include/neolib/neolib.hpp
+++ b/include/neolib/neolib.hpp
@@ -41,6 +41,8 @@
 #include <utility>
 #include <variant>
 
+#include <neolib/neolib_export.hpp>
+
 #ifdef NDEBUG
 constexpr bool ndebug = true;
 #else

--- a/include/neolib/plugin/plugin_manager.hpp
+++ b/include/neolib/plugin/plugin_manager.hpp
@@ -48,7 +48,7 @@
 
 namespace neolib
 {
-    class plugin_manager : public reference_counted<i_plugin_manager>
+    class NEOLIB_EXPORT plugin_manager : public reference_counted<i_plugin_manager>
     {
         // events
     public:

--- a/include/neolib/plugin/plugin_variant.hpp
+++ b/include/neolib/plugin/plugin_variant.hpp
@@ -95,7 +95,7 @@ namespace neolib
     }
 
     template <typename Id, typename... Types>
-    class plugin_variant : 
+    class plugin_variant :
         public reference_counted<i_plugin_variant<Id, abstract_t<Types>...>>,
         private variant<Types...>
     {

--- a/include/neolib/task/async_task.hpp
+++ b/include/neolib/task/async_task.hpp
@@ -49,7 +49,7 @@ namespace neolib
 {
     class async_task;
 
-    class timer_service : public i_timer_service
+    class NEOLIB_EXPORT timer_service : public i_timer_service
     {
         // types
     public:
@@ -69,7 +69,7 @@ namespace neolib
         dirty_list iDirtyObjectList;
     };
 
-    class io_service : public i_async_service
+    class NEOLIB_EXPORT io_service : public i_async_service
     {
         // types
     public:
@@ -87,7 +87,7 @@ namespace neolib
         native_io_service_type iNativeIoService;
     };
 
-    class async_task : public task<i_async_task>, public lifetime
+    class NEOLIB_EXPORT async_task : public task<i_async_task>, public lifetime
     {
         friend class async_thread;
         // events

--- a/include/neolib/task/async_thread.hpp
+++ b/include/neolib/task/async_thread.hpp
@@ -44,7 +44,7 @@ namespace neolib
 {
     class async_event_queue;
 
-    class async_thread : public thread
+    class NEOLIB_EXPORT async_thread : public thread
     {
         // types
     private:

--- a/include/neolib/task/event.hpp
+++ b/include/neolib/task/event.hpp
@@ -51,7 +51,7 @@
 
 namespace neolib
 {
-    class sink;
+    class NEOLIB_EXPORT sink;
 
     class event_handle
     {
@@ -182,7 +182,7 @@ namespace neolib
     };
 
     template <typename... Args>
-    class i_event_callable : public i_reference_counted
+    class NEOLIB_EXPORT i_event_callable : public i_reference_counted
     {
         typedef i_event_callable<Args...> self_type;
     public:
@@ -248,9 +248,9 @@ namespace neolib
     class async_task;
     class callback_timer;
 
-    void unqueue_event(const i_event& aEvent);
+    NEOLIB_EXPORT void unqueue_event(const i_event& aEvent);
 
-    class async_event_queue : public lifetime
+    class NEOLIB_EXPORT async_event_queue : public lifetime
     {
         template <typename...>
         friend class event;
@@ -316,7 +316,7 @@ namespace neolib
     };
 
     template <typename... Args>
-    class event : public i_event, public lifetime
+    class NEOLIB_EXPORT event : public i_event, public lifetime
     {
         typedef event<Args...> self_type;
         friend class sink;

--- a/include/neolib/task/thread.hpp
+++ b/include/neolib/task/thread.hpp
@@ -48,7 +48,7 @@
 
 namespace neolib
 {
-    class thread : public i_thread, public waitable, private noncopyable
+    class NEOLIB_EXPORT thread : public i_thread, public waitable, private noncopyable
     {
         // types
     public:

--- a/include/neolib/task/thread_pool.hpp
+++ b/include/neolib/task/thread_pool.hpp
@@ -48,7 +48,7 @@ namespace neolib
 {
     class thread_pool_thread;
 
-    class thread_pool
+    class NEOLIB_EXPORT thread_pool
     {
         friend class thread_pool_thread;
     public:

--- a/include/neolib/task/timer.hpp
+++ b/include/neolib/task/timer.hpp
@@ -47,7 +47,7 @@
 
 namespace neolib
 {
-    class timer : private noncopyable, public lifetime
+    class NEOLIB_EXPORT timer : private noncopyable, public lifetime
     {
         // types
     public:
@@ -103,7 +103,7 @@ namespace neolib
 #endif
     };
 
-    class callback_timer : public timer
+    class NEOLIB_EXPORT callback_timer : public timer
     {
     public:
         callback_timer(i_async_task& aTask, std::function<void(callback_timer&)> aCallback, uint32_t aDuration_ms, bool aInitialWait = true);

--- a/include/neolib/task/timer_object.hpp
+++ b/include/neolib/task/timer_object.hpp
@@ -45,7 +45,7 @@
 
 namespace neolib
 {
-    class timer_object : public reference_counted<i_timer_object>
+    class NEOLIB_EXPORT timer_object : public reference_counted<i_timer_object>
     {
     public:
         timer_object(i_timer_service& aService);

--- a/include/neolib/task/waitable_event.hpp
+++ b/include/neolib/task/waitable_event.hpp
@@ -47,7 +47,7 @@
 
 namespace neolib
 {
-    class waitable_event
+    class NEOLIB_EXPORT waitable_event
     {
         // constants
     public:


### PR DESCRIPTION
This allows building neolib as a shared library on Linux.
Because I used [GenerateExportHeader](https://cmake.org/cmake/help/latest/module/GenerateExportHeader.html), it should also work on Windows.
But I cannot verify this on MSVC2017. 
I tagged a lot of classes with `NEOLIB_EXPORT`. It might be possible that some were missed.